### PR TITLE
Add automatic release asset uploads

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,0 +1,34 @@
+name: Upload Release Assets
+
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  upload-assets:
+    name: Build and upload release assets
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build minified version
+        run: npm run build
+
+      - name: Upload assets to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" src/dynamic-url.js dist/dynamic-url.min.js


### PR DESCRIPTION
## Summary

Adds a new workflow (`.github/workflows/release-assets.yml`) that automatically uploads `dynamic-url.js` and `dynamic-url.min.js` as release assets whenever a GitHub release is created.

## How it works

On `release: created`, the workflow:
1. Checks out the code at the release tag
2. Installs dependencies and builds the minified version
3. Uploads both `src/dynamic-url.js` and `dist/dynamic-url.min.js` to the release

No more manual asset uploads for future releases.

## Test plan

- [x] Assets manually uploaded to v1.2.0 and v1.2.1 releases
- [ ] Workflow will be validated on the next release