### PR TITLE
fix(deps): patch serialize-javascript CPU-exhaustion DoS (alert #31)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2466,9 +2466,9 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "LICENSE"
   ],
   "overrides": {
-    "serialize-javascript": "^7.0.4"
+    "serialize-javascript": "^7.0.5"
   }
 }


### PR DESCRIPTION
## What

Bumps the existing `serialize-javascript` override floor from `^7.0.4` → `^7.0.5` and refreshes the lockfile, resolving the dependency to **7.0.7** (latest patched).

## Why

Resolves Dependabot alert #31 — *"Serialize JavaScript has CPU Exhaustion Denial of Service via crafted array-like objects"* (moderate, CVSS 5.9).

- **Vulnerable range:** `>=5.0.0 <7.0.5` · **Patched:** `7.0.5`
- The prior override `^7.0.4` still permitted the vulnerable `7.0.4`, and the lockfile was pinned exactly there.
- Dependabot could not auto-fix this: its only update path ran through mocha's own `serialize-javascript: ^6.0.2` constraint and would have downgraded mocha. Raising the override is the correct fix and respects the existing pattern from the earlier security-fix work.

## Scope / risk

- `serialize-javascript` is a **dev-only transitive dependency** (`mocha` → used at test time). It is **not** in the production tree and is **not** shipped to consumers (the published `files` list is `src/`, `dist/`, README, LICENSE only). No runtime impact for extension users.
- Patch-level bump within the 7.x line — no breaking changes.

## Testing

- `npm audit`: `serialize-javascript` no longer flagged.
- Full suite green locally — **76/76** (htmx v1/v2 × src/min) on headless Chrome.
- Diff is minimal: override line + the three `serialize-javascript` lockfile lines only.