### PR TITLE
fix(dependabot): actually batch security updates instead of one PR each

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,15 @@ updates:
       - dependency-name: "chai"
         versions: [">= 5.0.0"]
     groups:
+      # `groups` defaults to applies-to: version-updates, so security updates
+      # bypassed grouping entirely and arrived as one PR each. Both scopes need
+      # their own group to actually be batched.
       all-npm-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      all-npm-security-updates:
+        applies-to: security-updates
         patterns:
           - "*"
 
@@ -28,5 +36,10 @@ updates:
       - "FumingPower3925"
     groups:
       all-github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      all-github-actions-security-updates:
+        applies-to: security-updates
         patterns:
           - "*"


### PR DESCRIPTION
## Why grouping felt like it did nothing

Grouping was added on 2026-03-17, but PR volume stayed flat (~3.5/month). Here's why:

> **GitHub Dependabot options reference, `groups.applies-to`:** *"Specify which type of update the group applies to. When undefined, defaults to version updates."*

The existing groups had no `applies-to`, so they only ever batched **version updates**. Every **security update** bypassed grouping and arrived as its own individual PR.

Confirmed in this repo's own history — of the 14 npm PRs since grouping landed, only **4 were grouped**; **10 arrived solo** as security alerts.

## The fix

Adds a second group per ecosystem with `applies-to: security-updates`, and makes the existing groups' `version-updates` scope explicit rather than relying on the implicit default.

**No dependencies change.** This targets PR volume directly, which is the actual pain.