### PR TITLE
feat(ci): auto-merge Dependabot PRs once CI is green

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+# Workflows triggered by Dependabot get a read-only token by default; these
+# scopes are what let `gh pr merge --auto` act on the PR.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    # The repository guard stops forks from running this against their own copy.
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'FumingPower3925/htmx-dynamic-url'
+
+    steps:
+      - name: Enable auto-merge
+        # --auto queues the merge rather than performing it: main's branch
+        # protection holds the PR until every required CI check passes, and a
+        # red matrix leaves it sitting open. Every dependency here is dev-only
+        # and unreachable by consumers, so a green suite is a sufficient gate.
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Completes the churn-reduction work alongside #82 (which fixed the grouping gap).

## Why this is safe here

Every dependency in this repo is a **devDependency**. The published package ships `src/`, `dist/`, README and LICENSE with **zero runtime dependencies** — no consumer ever installs this tree. So a green 7-browser / 76-test matrix is a sufficient gate for dev-dep updates, and hand-merging each one is pure toil with no compensating safety benefit.

## How the gate works

Uses `gh pr merge --auto`, which **queues** the merge rather than performing it. `main`'s branch protection holds the PR until every required check passes; a red matrix leaves it sitting open for review. So this cannot merge anything broken.

Guarded on both the PR author being `dependabot[bot]` and the repository, so forks can't trigger it.

## Notes

- Deliberately **does not** use `dependabot/fetch-metadata`. That action exists to filter by update-type; since CI gates every update uniformly, there's nothing to filter — and it keeps one more action out of the tree.
- Requires the repo settings now enabled: `allow_auto_merge`, plus branch protection on `main` requiring the 7 test checks (`strict: false` so Dependabot isn't forced to rebase on every unrelated merge; no required reviews, which would otherwise deadlock auto-merge).